### PR TITLE
Fix decryption

### DIFF
--- a/programs/whispr/src/lib.rs
+++ b/programs/whispr/src/lib.rs
@@ -365,7 +365,7 @@ pub mod whispr {
             computation_offset: ctx.accounts.swap_state.computation_offset,
             deposit_amount,
             withdraw_amount,
-       
+            nonce: swap_result.nonce,
         });
 
         Ok(())
@@ -899,6 +899,7 @@ pub struct ConfidentialSwapExecutedEvent {
     pub computation_offset: u64,
     pub deposit_amount: [u8; 32],
     pub withdraw_amount: [u8; 32],
+    pub nonce: u128,
     // pub is_x: bool,
 }
 

--- a/tests/whispr.ts
+++ b/tests/whispr.ts
@@ -316,10 +316,9 @@ describe("Whispr", () => {
 
     console.log(swapExecutedEvent);
 
-    let deposit = cipher.decrypt([swapExecutedEvent.depositAmount], nonce);
-    let withdraw = cipher.decrypt([swapExecutedEvent.withdrawAmount], nonce);
-    console.log(`deposit amount is ${deposit}`);
-    console.log(`withdraw amount is ${withdraw}`);
+    let output = cipher.decrypt([swapExecutedEvent.depositAmount, swapExecutedEvent.withdrawAmount], swapExecutedEvent.nonce.toArrayLike(Buffer, "le", 16));
+    console.log(`deposit amount is ${output[0]}`);
+    console.log(`withdraw amount is ${output[1]}`);
 
     const executeTx = await program.methods
       .executeSwap()


### PR DESCRIPTION
Two things:
- When decrypting, we need to include the nonce that it was re-encrypted with. Small note: This nonce is the provided nonce + 1, so technically we don't need to pass it back, we could just do the old one +1 as well. 
- When decrypting, since we have 1 nonce for n ciphertexts, we need to use that nonce for those ciphertexts in order. The reason for this is because our cipher uses CTR mode, more info on this [here](https://xilinx.github.io/Vitis_Libraries/security/2019.2/guide_L1/internals/ctr.html). I think the picture explains why this important.